### PR TITLE
Simplify using Get-SmartCardCred

### DIFF
--- a/PowerShell/ReadFromAnySmartcard.ps1
+++ b/PowerShell/ReadFromAnySmartcard.ps1
@@ -131,7 +131,11 @@ namespace SmartCardLogon{
     $ValidCerts = [System.Security.Cryptography.X509Certificates.X509Certificate2[]](Get-ChildItem 'Cert:\CurrentUser\My' |
         Where-Object {$_.Extensions.EnhancedKeyUsages.Value -eq '1.3.6.1.4.1.311.20.2.2'})
         # Smart Card Log-on from KB287547 http://officeredir.microsoft.com/r/rlidGPOIDAndCrypt2O14?clid=1033
-    $Cert = [System.Security.Cryptography.X509Certificates.X509Certificate2UI]::SelectFromCollection($ValidCerts, 'Choose a certificate', 'Choose a certificate', 0)
+
+    if ($ValidCerts.Length -eq 1) {$Cert = $ValidCerts | Select-Object -First 1}
+    else {
+        $Cert = [System.Security.Cryptography.X509Certificates.X509Certificate2UI]::SelectFromCollection($ValidCerts, 'Choose a certificate', 'Choose a certificate', 0)
+    }
 
     $Pin = Read-Host "Enter your PIN: " -AsSecureString
 

--- a/PowerShell/ReadFromAnySmartcard.ps1
+++ b/PowerShell/ReadFromAnySmartcard.ps1
@@ -128,7 +128,9 @@ namespace SmartCardLogon{
     Add-Type -TypeDefinition $SmartCardCode -Language CSharp
     Add-Type -AssemblyName System.Security
 
-    $ValidCerts = [System.Security.Cryptography.X509Certificates.X509Certificate2[]](Get-ChildItem 'Cert:\CurrentUser\My')
+    $ValidCerts = [System.Security.Cryptography.X509Certificates.X509Certificate2[]](Get-ChildItem 'Cert:\CurrentUser\My' |
+        Where-Object {$_.Extensions.EnhancedKeyUsages.Value -eq '1.3.6.1.4.1.311.20.2.2'})
+        # Smart Card Log-on from KB287547 http://officeredir.microsoft.com/r/rlidGPOIDAndCrypt2O14?clid=1033
     $Cert = [System.Security.Cryptography.X509Certificates.X509Certificate2UI]::SelectFromCollection($ValidCerts, 'Choose a certificate', 'Choose a certificate', 0)
 
     $Pin = Read-Host "Enter your PIN: " -AsSecureString


### PR DESCRIPTION
Certificates without Smart Card Log-on usage aren't any help here, so don't list them in the certificate choices. If only one viable choice is found, don't bother offering the selection prompt at all.